### PR TITLE
raise dev tools and vscode version and adjust config accordingly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,6 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"configurations": [
 		{
 			"name": "Launch Extension",
@@ -10,19 +10,19 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
-			"preLaunchTask": "npm"
+			"outFiles": [
+                "${workspaceRoot}/out/src/**/*.js"
+			]
 		},
-		{
-			"name": "Launch Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outDir": "out/test",
-			"preLaunchTask": "npm"
+        {
+            "name": "Launch Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ]
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,22 +9,23 @@
 // A task runner that calls a custom npm script that compiles the extension.
 {
 	"version": "0.1.0",
+	"tasks": [
+		{
+			"taskName": "build",
 
-	// we want to run npm
-	"command": "npm",
+			// we want to run npm
+			"command": "npm",
 
-	// the command is a shell script
-	"isShellCommand": true,
+			// the command is a shell script
+			"isShellCommand": true,
 
-	// show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
+			"isBuildCommand": true,
 
-	// we run the custom script "compile" as defined in package.json
-	"args": ["run", "compile", "--loglevel", "silent"],
+			// show the output window only if unrecognized errors occur.
+			"showOutput": "silent",
 
-	// The tsc compiler is started in watching mode
-	"isWatching": true,
-
-	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
-	"problemMatcher": "$tsc-watch"
+			// we run the custom script "compile" as defined in package.json
+			"args": ["run", "compile", "--loglevel", "silent"]
+		}
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3192 @@
+{
+	"name": "scriptcsRunner",
+	"version": "0.1.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@types/node": {
+			"version": "6.0.85",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
+			"integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA==",
+			"dev": true
+		},
+		"ajv": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"json-stable-stringify": "1.0.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
+		},
+		"assert-plus": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+			"dev": true
+		},
+		"block-stream": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"boom": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+			"dev": true
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"dev": true
+		},
+		"camelcase-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"dev": true,
+			"requires": {
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
+			}
+		},
+		"caseless": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+			"dev": true
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
+			}
+		},
+		"clone": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+			"integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+			"dev": true
+		},
+		"clone-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+			"dev": true
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
+		},
+		"cloneable-readable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+			"integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"process-nextick-args": "1.0.7",
+				"through2": "2.0.3"
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"cryptiles": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
+			"requires": {
+				"boom": "2.10.1"
+			}
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
+			"requires": {
+				"array-find-index": "1.0.2"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"dateformat": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+			"integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
+			"dev": true
+		},
+		"debug": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+			"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+			"dev": true,
+			"requires": {
+				"ms": "0.7.1"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"deep-assign": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
+			"dev": true,
+			"requires": {
+				"is-obj": "1.0.1"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"diff": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+			"dev": true
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"duplexify": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+			"integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "1.4.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "0.1.1"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "1.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fancy-log": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+			"integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"time-stamp": "1.1.0"
+			}
+		},
+		"fd-slicer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"dev": true,
+			"requires": {
+				"pend": "1.2.0"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"find-up": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
+			"requires": {
+				"path-exists": "2.1.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"first-chunk-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+			"dev": true
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"dev": true,
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.5",
+				"mime-types": "2.1.16"
+			}
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fstream": {
+			"version": "0.1.31",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+			"integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "3.0.11",
+				"inherits": "2.0.3",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.1"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "3.0.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+					"integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+					"dev": true,
+					"requires": {
+						"natives": "1.1.0"
+					}
+				}
+			}
+		},
+		"generate-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
+		},
+		"generate-object-property": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
+			"requires": {
+				"is-property": "1.0.2"
+			}
+		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"glob": {
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+			"dev": true,
+			"requires": {
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"requires": {
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
+			}
+		},
+		"glob-stream": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"dev": true,
+			"requires": {
+				"extend": "3.0.1",
+				"glob": "5.0.15",
+				"glob-parent": "3.1.0",
+				"micromatch": "2.3.11",
+				"ordered-read-streams": "0.3.0",
+				"through2": "0.6.5",
+				"to-absolute-glob": "0.1.1",
+				"unique-stream": "2.2.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"glogg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+			"integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
+		},
+		"growl": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+			"dev": true
+		},
+		"gulp-chmod": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-1.3.0.tgz",
+			"integrity": "sha1-i7bowRiV3L+bQlIMh0NHpQIryw0=",
+			"dev": true,
+			"requires": {
+				"deep-assign": "1.0.0",
+				"stat-mode": "0.2.2",
+				"through2": "2.0.3"
+			}
+		},
+		"gulp-filter": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-4.0.0.tgz",
+			"integrity": "sha1-OV9YolbFWc254NFX8cqvUkijjcs=",
+			"dev": true,
+			"requires": {
+				"gulp-util": "3.0.8",
+				"multimatch": "2.1.0",
+				"streamfilter": "1.0.5"
+			}
+		},
+		"gulp-gunzip": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-0.0.3.tgz",
+			"integrity": "sha1-e24HsPWP09QlFcSOrVpj3wVy9i8=",
+			"dev": true,
+			"requires": {
+				"through2": "0.6.5",
+				"vinyl": "0.4.6"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+					"dev": true
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
+					}
+				},
+				"vinyl": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+					"dev": true,
+					"requires": {
+						"clone": "0.2.0",
+						"clone-stats": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-remote-src": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
+			"integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.3.4",
+				"node.extend": "1.1.6",
+				"request": "2.79.0",
+				"through2": "2.0.3",
+				"vinyl": "2.0.2"
+			},
+			"dependencies": {
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+					"dev": true
+				},
+				"replace-ext": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+					"dev": true
+				},
+				"request": {
+					"version": "2.79.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+					"dev": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.11.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "2.0.6",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.16",
+						"oauth-sign": "0.8.2",
+						"qs": "6.3.2",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.4.3",
+						"uuid": "3.1.0"
+					}
+				},
+				"vinyl": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+					"integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.2",
+						"clone-buffer": "1.0.0",
+						"clone-stats": "1.0.0",
+						"cloneable-readable": "1.0.0",
+						"is-stream": "1.1.0",
+						"remove-trailing-separator": "1.0.2",
+						"replace-ext": "1.0.0"
+					}
+				}
+			}
+		},
+		"gulp-sourcemaps": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"dev": true,
+			"requires": {
+				"convert-source-map": "1.5.0",
+				"graceful-fs": "4.1.11",
+				"strip-bom": "2.0.0",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.2",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-symdest": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+			"integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.3.4",
+				"mkdirp": "0.5.1",
+				"queue": "3.1.0",
+				"vinyl-fs": "2.4.4"
+			}
+		},
+		"gulp-untar": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.4.tgz",
+			"integrity": "sha1-Y1zH1n09SK7A28aYImI/x8M/fTc=",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.1.7",
+				"gulp-util": "2.2.20",
+				"streamifier": "0.1.1",
+				"tar": "0.1.20",
+				"through2": "0.4.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+					"integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "1.1.0",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "0.1.0",
+						"strip-ansi": "0.3.0",
+						"supports-color": "0.2.0"
+					}
+				},
+				"dateformat": {
+					"version": "1.0.12",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+					"integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+					"dev": true,
+					"requires": {
+						"get-stdin": "4.0.1",
+						"meow": "3.7.0"
+					}
+				},
+				"event-stream": {
+					"version": "3.1.7",
+					"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
+					"integrity": "sha1-tMVAAS0P4UmEIPPYlGAI22OTw3o=",
+					"dev": true,
+					"requires": {
+						"duplexer": "0.1.1",
+						"from": "0.1.7",
+						"map-stream": "0.1.0",
+						"pause-stream": "0.0.11",
+						"split": "0.2.10",
+						"stream-combiner": "0.0.4",
+						"through": "2.3.8"
+					}
+				},
+				"gulp-util": {
+					"version": "2.2.20",
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+					"integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
+					"dev": true,
+					"requires": {
+						"chalk": "0.5.1",
+						"dateformat": "1.0.12",
+						"lodash._reinterpolate": "2.4.1",
+						"lodash.template": "2.4.1",
+						"minimist": "0.2.0",
+						"multipipe": "0.1.2",
+						"through2": "0.5.1",
+						"vinyl": "0.2.3"
+					},
+					"dependencies": {
+						"through2": {
+							"version": "0.5.1",
+							"resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+							"integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
+							"dev": true,
+							"requires": {
+								"readable-stream": "1.0.34",
+								"xtend": "3.0.0"
+							}
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+					"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "0.2.1"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"lodash._reinterpolate": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+					"integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI=",
+					"dev": true
+				},
+				"lodash.escape": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+					"integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
+					"dev": true,
+					"requires": {
+						"lodash._escapehtmlchar": "2.4.1",
+						"lodash._reunescapedhtml": "2.4.1",
+						"lodash.keys": "2.4.1"
+					}
+				},
+				"lodash.keys": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+					"dev": true,
+					"requires": {
+						"lodash._isnative": "2.4.1",
+						"lodash._shimkeys": "2.4.1",
+						"lodash.isobject": "2.4.1"
+					}
+				},
+				"lodash.template": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+					"integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
+					"dev": true,
+					"requires": {
+						"lodash._escapestringchar": "2.4.1",
+						"lodash._reinterpolate": "2.4.1",
+						"lodash.defaults": "2.4.1",
+						"lodash.escape": "2.4.1",
+						"lodash.keys": "2.4.1",
+						"lodash.templatesettings": "2.4.1",
+						"lodash.values": "2.4.1"
+					}
+				},
+				"lodash.templatesettings": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+					"integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
+					"dev": true,
+					"requires": {
+						"lodash._reinterpolate": "2.4.1",
+						"lodash.escape": "2.4.1"
+					}
+				},
+				"minimist": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+					"integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"split": {
+					"version": "0.2.10",
+					"resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+					"integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+					"dev": true,
+					"requires": {
+						"through": "2.3.8"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "0.2.1"
+					}
+				},
+				"supports-color": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+					"integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+					"dev": true
+				},
+				"through2": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+					"integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "2.1.2"
+					},
+					"dependencies": {
+						"xtend": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+							"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+							"dev": true,
+							"requires": {
+								"object-keys": "0.4.0"
+							}
+						}
+					}
+				},
+				"vinyl": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+					"integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
+					"dev": true,
+					"requires": {
+						"clone-stats": "0.0.1"
+					}
+				},
+				"xtend": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+					"dev": true
+				}
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"dev": true,
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-uniq": "1.0.3",
+				"beeper": "1.1.1",
+				"chalk": "1.1.3",
+				"dateformat": "2.0.0",
+				"fancy-log": "1.3.0",
+				"gulplog": "1.0.0",
+				"has-gulplog": "0.1.0",
+				"lodash._reescape": "3.0.0",
+				"lodash._reevaluate": "3.0.0",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.template": "3.6.2",
+				"minimist": "1.2.0",
+				"multipipe": "0.1.2",
+				"object-assign": "3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "2.0.3",
+				"vinyl": "0.5.3"
+			}
+		},
+		"gulp-vinyl-zip": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
+			"integrity": "sha1-VjgvLMtXIxuwR4x4c3zNVylzvuE=",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.3.4",
+				"queue": "3.1.0",
+				"through2": "0.6.5",
+				"vinyl": "0.4.6",
+				"vinyl-fs": "2.4.4",
+				"yauzl": "2.8.0",
+				"yazl": "2.4.2"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+					"dev": true
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
+					}
+				},
+				"vinyl": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+					"dev": true,
+					"requires": {
+						"clone": "0.2.0",
+						"clone-stats": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"dev": true,
+			"requires": {
+				"glogg": "1.0.0"
+			}
+		},
+		"har-schema": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"commander": "2.11.0",
+				"is-my-json-valid": "2.16.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"dev": true,
+			"requires": {
+				"boom": "2.10.1",
+				"cryptiles": "2.0.5",
+				"hoek": "2.16.3",
+				"sntp": "1.0.9"
+			}
+		},
+		"hoek": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+			"dev": true
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"dev": true
+		},
+		"http-signature": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "0.2.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"indent-string": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+			"dev": true,
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"is": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+			"integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+			"dev": true
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
+		"is-buffer": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+			"dev": true
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "2.1.1"
+			}
+		},
+		"is-my-json-valid": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+			"integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+			"dev": true,
+			"requires": {
+				"generate-function": "2.0.0",
+				"generate-object-property": "1.2.0",
+				"jsonpointer": "4.0.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
+		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"jade": {
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+			"integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+			"dev": true,
+			"requires": {
+				"commander": "0.6.1",
+				"mkdirp": "0.3.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+					"integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+					"integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+					"dev": true
+				}
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
+			"optional": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
+		},
+		"jsonpointer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "1.1.5"
+			}
+		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+			"dev": true
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+			"dev": true
+		},
+		"lodash._escapehtmlchar": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+			"integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
+			"dev": true,
+			"requires": {
+				"lodash._htmlescapes": "2.4.1"
+			}
+		},
+		"lodash._escapestringchar": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+			"integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I=",
+			"dev": true
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"lodash._htmlescapes": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+			"integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
+			"dev": true
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
+		"lodash._isnative": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+			"integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+			"dev": true
+		},
+		"lodash._objecttypes": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+			"integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+			"dev": true
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+			"dev": true
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+			"dev": true
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash._reunescapedhtml": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+			"integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
+			"dev": true,
+			"requires": {
+				"lodash._htmlescapes": "2.4.1",
+				"lodash.keys": "2.4.1"
+			},
+			"dependencies": {
+				"lodash.keys": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+					"dev": true,
+					"requires": {
+						"lodash._isnative": "2.4.1",
+						"lodash._shimkeys": "2.4.1",
+						"lodash.isobject": "2.4.1"
+					}
+				}
+			}
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+			"dev": true
+		},
+		"lodash._shimkeys": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+			"integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+			"dev": true,
+			"requires": {
+				"lodash._objecttypes": "2.4.1"
+			}
+		},
+		"lodash.defaults": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+			"integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
+			"dev": true,
+			"requires": {
+				"lodash._objecttypes": "2.4.1",
+				"lodash.keys": "2.4.1"
+			},
+			"dependencies": {
+				"lodash.keys": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+					"dev": true,
+					"requires": {
+						"lodash._isnative": "2.4.1",
+						"lodash._shimkeys": "2.4.1",
+						"lodash.isobject": "2.4.1"
+					}
+				}
+			}
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"dev": true,
+			"requires": {
+				"lodash._root": "3.0.1"
+			}
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
+		},
+		"lodash.isobject": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+			"integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+			"dev": true,
+			"requires": {
+				"lodash._objecttypes": "2.4.1"
+			}
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
+		},
+		"lodash.template": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash._basetostring": "3.0.1",
+				"lodash._basevalues": "3.0.0",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0",
+				"lodash.keys": "3.1.2",
+				"lodash.restparam": "3.6.1",
+				"lodash.templatesettings": "3.1.1"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0"
+			}
+		},
+		"lodash.values": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+			"integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
+			"dev": true,
+			"requires": {
+				"lodash.keys": "2.4.1"
+			},
+			"dependencies": {
+				"lodash.keys": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+					"dev": true,
+					"requires": {
+						"lodash._isnative": "2.4.1",
+						"lodash._shimkeys": "2.4.1",
+						"lodash.isobject": "2.4.1"
+					}
+				}
+			}
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"dev": true,
+			"requires": {
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"lru-cache": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+			"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+			"dev": true
+		},
+		"map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+			"dev": true
+		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
+		"meow": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"dev": true,
+			"requires": {
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"dev": true
+				}
+			}
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.3"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"mime-db": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.16",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.29.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "1.1.8"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"mocha": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+			"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+			"dev": true,
+			"requires": {
+				"commander": "2.3.0",
+				"debug": "2.2.0",
+				"diff": "1.4.0",
+				"escape-string-regexp": "1.0.2",
+				"glob": "3.2.11",
+				"growl": "1.9.2",
+				"jade": "0.26.3",
+				"mkdirp": "0.5.1",
+				"supports-color": "1.2.0",
+				"to-iso-string": "0.0.2"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+					"dev": true
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3",
+						"minimatch": "0.3.0"
+					}
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "2.7.3",
+						"sigmund": "1.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+					"dev": true
+				}
+			}
+		},
+		"ms": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+			"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+			"dev": true
+		},
+		"multimatch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"dev": true,
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
+			}
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"dev": true,
+			"requires": {
+				"duplexer2": "0.0.2"
+			}
+		},
+		"natives": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+			"integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+			"dev": true
+		},
+		"node.extend": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+			"integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+			"dev": true,
+			"requires": {
+				"is": "3.2.1"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.4.1",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "1.0.2"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+			"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+			"dev": true
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"ordered-read-streams": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"dev": true,
+			"requires": {
+				"is-stream": "1.1.0",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
+			"requires": {
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+			"dev": true
+		},
+		"performance-now": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+			"dev": true
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"dev": true
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+			"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+			"dev": true
+		},
+		"queue": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+			"integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.5"
+					}
+				}
+			}
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"dev": true,
+			"requires": {
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "1.0.7",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"redent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"dev": true,
+			"requires": {
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "0.1.3",
+				"is-primitive": "2.0.0"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
+		},
+		"request": {
+			"version": "2.81.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "0.6.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.5",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.1.4",
+				"har-validator": "4.2.1",
+				"hawk": "3.1.3",
+				"http-signature": "1.1.1",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.16",
+				"oauth-sign": "0.8.2",
+				"performance-now": "0.2.0",
+				"qs": "6.4.0",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.2",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.1.0"
+			},
+			"dependencies": {
+				"caseless": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+					"dev": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+					"dev": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"qs": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+					"dev": true
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"rimraf": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"dev": true
+		},
+		"sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"sntp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"source-map": {
+			"version": "0.1.32",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+			"integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+			"dev": true,
+			"requires": {
+				"amdefine": "1.0.1"
+			}
+		},
+		"source-map-support": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
+			"integrity": "sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=",
+			"dev": true,
+			"requires": {
+				"source-map": "0.1.32"
+			}
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"dev": true,
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
+		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"stat-mode": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+			"integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+			"dev": true
+		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
+		},
+		"streamfilter": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
+			"integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"streamifier": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+			"integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+			"dev": true
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"dev": true,
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-bom-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+			"dev": true,
+			"requires": {
+				"first-chunk-stream": "1.0.0",
+				"strip-bom": "2.0.0"
+			}
+		},
+		"strip-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+			"dev": true,
+			"requires": {
+				"get-stdin": "4.0.1"
+			}
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"tar": {
+			"version": "0.1.20",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+			"integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
+			"dev": true,
+			"requires": {
+				"block-stream": "0.0.9",
+				"fstream": "0.1.31",
+				"inherits": "2.0.3"
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"through2-filter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"dev": true,
+			"requires": {
+				"through2": "2.0.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
+		},
+		"to-absolute-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "2.0.1"
+			}
+		},
+		"to-iso-string": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+			"integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+			"dev": true
+		},
+		"tough-cookie": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+			"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"trim-newlines": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+			"dev": true
+		},
+		"tunnel-agent": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+			"dev": true
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
+			"optional": true
+		},
+		"typescript": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+			"integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+			"dev": true
+		},
+		"unique-stream": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"dev": true,
+			"requires": {
+				"json-stable-stringify": "1.0.1",
+				"through2-filter": "2.0.0"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"uuid": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+			"dev": true
+		},
+		"vali-date": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"vinyl": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+			"dev": true,
+			"requires": {
+				"clone": "1.0.2",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-fs": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"dev": true,
+			"requires": {
+				"duplexify": "3.5.1",
+				"glob-stream": "5.3.5",
+				"graceful-fs": "4.1.11",
+				"gulp-sourcemaps": "1.6.0",
+				"is-valid-glob": "0.3.0",
+				"lazystream": "1.0.0",
+				"lodash.isequal": "4.5.0",
+				"merge-stream": "1.0.1",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.3",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "1.0.0",
+				"through2": "2.0.3",
+				"through2-filter": "2.0.0",
+				"vali-date": "1.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"dev": true
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.2",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vinyl-source-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+			"integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
+			"dev": true,
+			"requires": {
+				"through2": "0.6.5",
+				"vinyl": "0.4.6"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+					"dev": true
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
+					}
+				},
+				"vinyl": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+					"dev": true,
+					"requires": {
+						"clone": "0.2.0",
+						"clone-stats": "0.0.1"
+					}
+				}
+			}
+		},
+		"vscode": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.0.0.tgz",
+			"integrity": "sha1-kMFIy6NhQIa9uY9P5LTgTzQLeW8=",
+			"dev": true,
+			"requires": {
+				"glob": "5.0.15",
+				"gulp-chmod": "1.3.0",
+				"gulp-filter": "4.0.0",
+				"gulp-gunzip": "0.0.3",
+				"gulp-remote-src": "0.4.3",
+				"gulp-symdest": "1.1.0",
+				"gulp-untar": "0.0.4",
+				"gulp-vinyl-zip": "1.4.0",
+				"mocha": "2.5.3",
+				"request": "2.81.0",
+				"semver": "5.4.1",
+				"source-map-support": "0.3.3",
+				"vinyl-source-stream": "1.1.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
+		},
+		"yauzl": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+			"integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+			"dev": true,
+			"requires": {
+				"buffer-crc32": "0.2.13",
+				"fd-slicer": "1.0.1"
+			}
+		},
+		"yazl": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
+			"integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
+			"dev": true,
+			"requires": {
+				"buffer-crc32": "0.2.13"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
 		"type": "git",
 		"url": "https://github.com/filipw/vscode-scriptcs-runner.git"
 	},
-  "icon": "images/scriptcs.png",
+	"icon": "images/scriptcs.png",
 	"engines": {
-		"vscode": "^0.10.1"
+		"vscode": "^1.0.0"
 	},
 	"categories": [
 		"Other"
@@ -17,41 +17,47 @@
 	"activationEvents": [
 		"onCommand:extension.scriptcsRunner"
 	],
-	"main": "./out/extension",
+	"main": "./out/src/extension",
 	"contributes": {
-		"commands": [{
-			"command": "extension.scriptcsRunner",
-			"title": "Execute with scriptcs"
-		}],
-    "configuration": {
-        "type": "object",
-        "title": "ScriptCsRunner configuration",
-        "properties": {
-            "scriptcsRunner.scriptcsPath": {
-                "type": "string",
-                "default": "scriptcs",
-                "description": "Location of scriptcs executable. Defaults to 'scriptcs', meaning it just tries to use your PATH environment variable."
-            },
-            "scriptcsRunner.debug": {
-                "type": "boolean",
-                "default": false,
-                "description": "Specifies whether C# scripts/snippets should be executed in debug mode."
-            }
-        }
-    },
-    "keybindings": [{
-        "command": "extension.scriptcsRunner",
-        "key": "ctrl+shift+r",
-        "mac": "cmd+shift+r",
-        "when": "editorTextFocus"
-    }]        
+		"commands": [
+			{
+				"command": "extension.scriptcsRunner",
+				"title": "Execute with scriptcs"
+			}
+		],
+		"configuration": {
+			"type": "object",
+			"title": "ScriptCsRunner configuration",
+			"properties": {
+				"scriptcsRunner.scriptcsPath": {
+					"type": "string",
+					"default": "scriptcs",
+					"description": "Location of scriptcs executable. Defaults to 'scriptcs', meaning it just tries to use your PATH environment variable."
+				},
+				"scriptcsRunner.debug": {
+					"type": "boolean",
+					"default": false,
+					"description": "Specifies whether C# scripts/snippets should be executed in debug mode."
+				}
+			}
+		},
+		"keybindings": [
+			{
+				"command": "extension.scriptcsRunner",
+				"key": "ctrl+shift+r",
+				"mac": "cmd+shift+r",
+				"when": "editorTextFocus"
+			}
+		]
 	},
 	"scripts": {
-		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
+		"vscode:prepublish": "tsc -p ./",
+		"compile": "tsc -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
 	"devDependencies": {
-		"typescript": "^1.6.2",
-		"vscode": "0.10.x"
+		"typescript": "^2.0.3",
+		"vscode": "1.0.0",
+		"@types/node": "^6.0.40"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,16 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES5",
+		"lib": [
+			"es6"
+		],
+		"target": "es6",
 		"outDir": "out",
-		"noLib": true,
-		"sourceMap": true
+		"sourceMap": true,
+		"rootDir": "."
 	},
 	"exclude": [
-		"node_modules"
+		"node_modules",
+		".vscode-test"
 	]
 }

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
Some package config etc. required a "migration" to be able to debug/develop in current version of vscode.
Removed PreLaunchTask so initially it has to be built manually via shortcut and then can be normally launched in debug instance with current compiled version.